### PR TITLE
Fix benchmarks

### DIFF
--- a/bench/witchcraft/applicative/function_bench.exs
+++ b/bench/witchcraft/applicative/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Applicative.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Applicative
 

--- a/bench/witchcraft/applicative/list_bench.exs
+++ b/bench/witchcraft/applicative/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Applicative.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Applicative
 

--- a/bench/witchcraft/applicative/tuple_bench.exs
+++ b/bench/witchcraft/applicative/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Applicative.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Applicative
 

--- a/bench/witchcraft/apply/function_bench.exs
+++ b/bench/witchcraft/apply/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Apply.FunBench do
+  @moduledoc false
+
   import Kernel, except: [then: 2]
 
   use Benchfella

--- a/bench/witchcraft/apply/function_bench.exs
+++ b/bench/witchcraft/apply/function_bench.exs
@@ -1,6 +1,9 @@
 defmodule Witchcraft.Apply.FunBench do
+  import Kernel, except: [then: 2]
+
   use Benchfella
   use Witchcraft.Apply
+
 
   #########
   # Setup #

--- a/bench/witchcraft/apply/list_bench.exs
+++ b/bench/witchcraft/apply/list_bench.exs
@@ -1,6 +1,8 @@
 defmodule Witchcraft.Apply.ListBench do
+  @moduledoc false
+
   import Kernel, except: [then: 2]
-  
+
   use Benchfella
   use Witchcraft.Apply
 

--- a/bench/witchcraft/apply/list_bench.exs
+++ b/bench/witchcraft/apply/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Apply.ListBench do
+  import Kernel, except: [then: 2]
+  
   use Benchfella
   use Witchcraft.Apply
 

--- a/bench/witchcraft/apply/tuple_bench.exs
+++ b/bench/witchcraft/apply/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Apply.TupleBench do
+  import Kernel, except: [then: 2]
+  
   use Benchfella
   use Witchcraft.Apply
 

--- a/bench/witchcraft/apply/tuple_bench.exs
+++ b/bench/witchcraft/apply/tuple_bench.exs
@@ -1,6 +1,8 @@
 defmodule Witchcraft.Apply.TupleBench do
+  @moduledoc false
+
   import Kernel, except: [then: 2]
-  
+
   use Benchfella
   use Witchcraft.Apply
 

--- a/bench/witchcraft/arrow/function_bench.exs
+++ b/bench/witchcraft/arrow/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Arrow.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Arrow
 

--- a/bench/witchcraft/arrow/function_bench.exs
+++ b/bench/witchcraft/arrow/function_bench.exs
@@ -15,7 +15,7 @@ defmodule Witchcraft.Arrow.FunctionBench do
 
   defp f(x), do: "#{inspect x}/#{inspect x}"
   defp g(y), do: "#{inspect y}-#{inspect y}-#{inspect y}"
-  defp h(z), do: "!#{inspect y}!"
+  defp h(z), do: "!#{inspect z}!"
 
   #########
   # Arrow #

--- a/bench/witchcraft/bifunctor/tuple_bench.exs
+++ b/bench/witchcraft/bifunctor/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Bifunctor.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Bifunctor
 

--- a/bench/witchcraft/category/function_bench.exs
+++ b/bench/witchcraft/category/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Category.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Category
 

--- a/bench/witchcraft/chain/function_bench.exs
+++ b/bench/witchcraft/chain/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Chain.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Chain
 

--- a/bench/witchcraft/chain/list_bench.exs
+++ b/bench/witchcraft/chain/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Chain.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Chain
 

--- a/bench/witchcraft/chain/tuple_bench.exs
+++ b/bench/witchcraft/chain/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Chain.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Chain
 

--- a/bench/witchcraft/comonad/tuple_bench.exs
+++ b/bench/witchcraft/comonad/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Comonad.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Comonad
 

--- a/bench/witchcraft/extend/function_bench.exs
+++ b/bench/witchcraft/extend/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Extend.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Extend
   use Quark

--- a/bench/witchcraft/extend/list_bench.exs
+++ b/bench/witchcraft/extend/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Extend.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Extend
 

--- a/bench/witchcraft/extend/tuple_bench.exs
+++ b/bench/witchcraft/extend/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Extend.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Extend
 

--- a/bench/witchcraft/foldable/bitstring_bench.exs
+++ b/bench/witchcraft/foldable/bitstring_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Foldable.BitStringBench do
+  @moduledoc false
+
   require Integer
 
   use Benchfella

--- a/bench/witchcraft/foldable/list_bench.exs
+++ b/bench/witchcraft/foldable/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Foldable.ListBench do
+  @moduledoc false
+
   require Integer
 
   use Benchfella

--- a/bench/witchcraft/foldable/map_bench.exs
+++ b/bench/witchcraft/foldable/map_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Foldable.MapBench do
+  @moduledoc false
+
   require Integer
 
   use Benchfella

--- a/bench/witchcraft/foldable/tuple_bench.exs
+++ b/bench/witchcraft/foldable/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Foldable.TupleBench do
+  @moduledoc false
+
   require Integer
 
   use Benchfella

--- a/bench/witchcraft/functor/function_bench.exs
+++ b/bench/witchcraft/functor/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Functor.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Functor
 

--- a/bench/witchcraft/functor/list_bench.exs
+++ b/bench/witchcraft/functor/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Functor.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Functor
 

--- a/bench/witchcraft/functor/map_bench.exs
+++ b/bench/witchcraft/functor/map_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Functor.MapBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Functor
 

--- a/bench/witchcraft/functor/tuple_bench.exs
+++ b/bench/witchcraft/functor/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Functor.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Functor
 

--- a/bench/witchcraft/monad/function_bench.exs
+++ b/bench/witchcraft/monad/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monad.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monad
   use Quark

--- a/bench/witchcraft/monad/function_bench.exs
+++ b/bench/witchcraft/monad/function_bench.exs
@@ -52,7 +52,7 @@ defmodule Witchcraft.Monad.FunctionBench do
   end
 
   bench "async_draw/2" do
-    fn h ->h <|> h end
+    fn h -> h <|> h end
     |> async_draw((fn f ->
       fn g ->
         f <|> g <|> g <|> f

--- a/bench/witchcraft/monad/list_bench.exs
+++ b/bench/witchcraft/monad/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monad.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monad
   use Quark

--- a/bench/witchcraft/monad/tuple_bench.exs
+++ b/bench/witchcraft/monad/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monad.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monad
   use Quark

--- a/bench/witchcraft/monoid/bitstring_bench.exs
+++ b/bench/witchcraft/monoid/bitstring_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.BitStringBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/monoid/float_bench.exs
+++ b/bench/witchcraft/monoid/float_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.FloatBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/monoid/function_bench.exs
+++ b/bench/witchcraft/monoid/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/monoid/integer_bench.exs
+++ b/bench/witchcraft/monoid/integer_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.IntegerBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/monoid/list_bench.exs
+++ b/bench/witchcraft/monoid/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/monoid/map_bench.exs
+++ b/bench/witchcraft/monoid/map_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.MapBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/monoid/map_set_bench.exs
+++ b/bench/witchcraft/monoid/map_set_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.MapSetBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/monoid/tuple_bench.exs
+++ b/bench/witchcraft/monoid/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Monoid.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Monoid
 

--- a/bench/witchcraft/ord/bitstring.exs
+++ b/bench/witchcraft/ord/bitstring.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Ord.BitStringBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Ord
 

--- a/bench/witchcraft/ord/float_bench.exs
+++ b/bench/witchcraft/ord/float_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Ord.FloatBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Ord
 

--- a/bench/witchcraft/ord/integer_bench.exs
+++ b/bench/witchcraft/ord/integer_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Ord.IntegerBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Ord
 

--- a/bench/witchcraft/ord/list_bench.exs
+++ b/bench/witchcraft/ord/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Ord.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Ord
 

--- a/bench/witchcraft/ord/map_bench.exs
+++ b/bench/witchcraft/ord/map_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Ord.MapBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Ord
 

--- a/bench/witchcraft/ord/tuple_bench.exs
+++ b/bench/witchcraft/ord/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Ord.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Ord
 

--- a/bench/witchcraft/semigroup/bitstring_bench.exs
+++ b/bench/witchcraft/semigroup/bitstring_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.BitStringBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/float_bench.exs
+++ b/bench/witchcraft/semigroup/float_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.FloatBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/function_bench.exs
+++ b/bench/witchcraft/semigroup/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/integer_bench.exs
+++ b/bench/witchcraft/semigroup/integer_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.IntegerBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/list_bench.exs
+++ b/bench/witchcraft/semigroup/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/map_bench.exs
+++ b/bench/witchcraft/semigroup/map_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.MapBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/mapset_bench 2.exs
+++ b/bench/witchcraft/semigroup/mapset_bench 2.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.MapBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/mapset_bench.exs
+++ b/bench/witchcraft/semigroup/mapset_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.MapSetBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroup/tuple_bench.exs
+++ b/bench/witchcraft/semigroup/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroup.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroup
 

--- a/bench/witchcraft/semigroupoid/function_bench.exs
+++ b/bench/witchcraft/semigroupoid/function_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Semigroupoid.FunctionBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Semigroupoid
 

--- a/bench/witchcraft/setoid/bitstring_bench.exs
+++ b/bench/witchcraft/setoid/bitstring_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Setoid.BitStringBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Setoid
 

--- a/bench/witchcraft/setoid/float_bench.exs
+++ b/bench/witchcraft/setoid/float_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Setoid.FloatBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Setoid
 

--- a/bench/witchcraft/setoid/integer_bench.exs
+++ b/bench/witchcraft/setoid/integer_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Setoid.IntegerBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Setoid
 

--- a/bench/witchcraft/setoid/list_bench.exs
+++ b/bench/witchcraft/setoid/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Setoid.ListBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Setoid
 

--- a/bench/witchcraft/setoid/map_bench.exs
+++ b/bench/witchcraft/setoid/map_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Setoid.MapBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Setoid
 

--- a/bench/witchcraft/setoid/map_set_bench.exs
+++ b/bench/witchcraft/setoid/map_set_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Setoid.MapSetBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Setoid
 

--- a/bench/witchcraft/setoid/tuple_bench.exs
+++ b/bench/witchcraft/setoid/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Setoid.TupleBench do
+  @moduledoc false
+
   use Benchfella
   use Witchcraft.Setoid
 

--- a/bench/witchcraft/traversable/list_bench.exs
+++ b/bench/witchcraft/traversable/list_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Traversable.ListBench do
+  @moduledoc false
+
   require Integer
 
   use Benchfella

--- a/bench/witchcraft/traversable/tuple_bench.exs
+++ b/bench/witchcraft/traversable/tuple_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.Traversable.TupleBench do
+  @moduledoc false
+
   require Integer
 
   use Benchfella

--- a/bench/witchcraft/unit_bench.exs
+++ b/bench/witchcraft/unit_bench.exs
@@ -1,4 +1,6 @@
 defmodule Witchcraft.UnitBench do
+  @moduledoc false
+
   use Benchfella
   import Witchcraft.Unit
 


### PR DESCRIPTION
## Summary
Fixes compilation errors in benchmarks, as described in #96 and usage of `Witchcraft.Apply.then/2`.
Also adds `@moduledoc false` to each benchmark module

## Test plan (required)

run `mix bench`

## Closing issues

Fixes #96