### PR TITLE
Fix various documentation references and typespecs

### DIFF
--- a/lib/witchcraft/apply.ex
+++ b/lib/witchcraft/apply.ex
@@ -545,7 +545,7 @@ defclass Witchcraft.Apply do
       [-2, -3, -1, -2, 1, 0, 3, 2]
 
   """
-  @spec over(fun(), Apply.t(), Apply.t(), Apply.t()) :: Apply.t()
+  @spec over(fun(), Apply.t(), Apply.t(), Apply.t(), Apply.t()) :: Apply.t()
   def over(fun, a, b, c, d), do: fun |> over(a, b, c) |> ap(d)
 
   @doc """
@@ -587,7 +587,7 @@ defclass Witchcraft.Apply do
       [-2, -3, -1, -2, 1, 0, 3, 2]
 
   """
-  @spec async_over(fun(), Apply.t(), Apply.t(), Apply.t()) :: Apply.t()
+  @spec async_over(fun(), Apply.t(), Apply.t(), Apply.t(), Apply.t()) :: Apply.t()
   def async_over(fun, a, b, c, d), do: fun |> async_over(a, b, c) |> async_ap(d)
 end
 

--- a/lib/witchcraft/arrow.ex
+++ b/lib/witchcraft/arrow.ex
@@ -449,7 +449,7 @@ defclass Witchcraft.Arrow do
       430
 
   """
-  @spec precompose(Arrow.t(), fun()) :: Arrow.t()
+  @spec postcompose(Arrow.t(), fun()) :: Arrow.t()
   def postcompose(arrow, fun), do: arrow <~> arrowize(arrow, fun)
 end
 

--- a/lib/witchcraft/chain.ex
+++ b/lib/witchcraft/chain.ex
@@ -254,7 +254,7 @@ defclass Witchcraft.Chain do
 
   Sequences chainable actions. Note that each line must be of the same type.
 
-  For a version with `return`, please see `Witchcraft.Monad.do/2`
+  For a version with `return`, please see `Witchcraft.Monad.monad/2`
 
   ## Examples
 

--- a/lib/witchcraft/foldable.ex
+++ b/lib/witchcraft/foldable.ex
@@ -337,7 +337,7 @@ defclass Witchcraft.Foldable do
       2
 
   """
-  @spec max(Foldable.t(), by: (any, any -> Order.ordering())) :: Ord.t()
+  @spec max(Foldable.t(), by: (any, any -> Ord.ordering())) :: Ord.t()
   def max(foldable, by: comparator) do
     Witchcraft.Foldable.right_fold(foldable, fn focus, acc ->
       case comparator.(focus, acc) do
@@ -395,7 +395,7 @@ defclass Witchcraft.Foldable do
       8
 
   """
-  @spec min(Foldable.t(), by: (any(), any() -> Order.t())) :: any() | Maybe.t()
+  @spec min(Foldable.t(), by: (any(), any() -> Ord.t())) :: any()
   def min(foldable, by: comparitor) do
     right_fold(foldable, fn focus, acc ->
       case comparitor.(focus, acc) do
@@ -787,6 +787,6 @@ defclass Witchcraft.Foldable do
       ]
 
   """
-  @spec then_traverse(Apply.fun(), Foldable.t()) :: Apply.t()
+  @spec then_through(Apply.fun(), Foldable.t()) :: Apply.t()
   def then_through(fun, traversable), do: then_traverse(traversable, fun)
 end

--- a/lib/witchcraft/monad.ex
+++ b/lib/witchcraft/monad.ex
@@ -19,7 +19,7 @@ defclass Witchcraft.Monad do
   For a nice, illustrated introduction,
   see [Functors, Applicatives, And Monads In Pictures](http://adit.io/posts/2013-04-17-functors,_applicatives,_and_monads_in_pictures.html).
 
-  Having `of` also lets us enhance do-notation with a convenuenct `return` function (see `monad/2`)
+  Having `of` also lets us enhance do-notation with a convenient `return` function (see `monad/2`)
 
   ## Type Class
 
@@ -36,6 +36,8 @@ defclass Witchcraft.Monad do
                          [_]
   """
 
+  alias Witchcraft.Chain
+
   extend Witchcraft.Applicative
   extend Witchcraft.Chain
 
@@ -43,6 +45,8 @@ defclass Witchcraft.Monad do
 
   use Witchcraft.Applicative
   use Witchcraft.Chain
+
+  @type t :: any()
 
   properties do
     import Witchcraft.Applicative
@@ -110,7 +114,7 @@ defclass Witchcraft.Monad do
   end
 
   @doc "Alias for `async_chain/2`"
-  @spec async_chain(Chain.t(), Chain.link()) :: Chain.t()
+  @spec async_bind(Chain.t(), Chain.link()) :: Chain.t()
   def async_bind(chainable, link), do: async_chain(chainable, link)
 
   @doc """


### PR DESCRIPTION
Here's a few minor issues I noticed while publishing docs.

There's a few classes of fixes here:
- References to types in modules that haven't been aliased
- References to types that haven't been defined
- Overlapping typespecs that refer to the wrong function name or arity