### PR TITLE
Make Witchcraft.Chain.do_notation respect chainer

### DIFF
--- a/lib/witchcraft/chain.ex
+++ b/lib/witchcraft/chain.ex
@@ -407,7 +407,7 @@ defclass Witchcraft.Chain do
 
   @doc false
   # credo:disable-for-lines:31 Credo.Check.Refactor.Nesting
-  def do_notation(input, _chainer) do
+  def do_notation(input, chainer) do
     input
     |> normalize()
     |> Enum.reverse()
@@ -416,17 +416,10 @@ defclass Witchcraft.Chain do
         quote do: unquote(value) |> (fn unquote(assign) -> unquote(continue) end).()
 
       continue, {:<-, _, [assign, value]} ->
-        quote do
-          import Witchcraft.Chain, only: [>>>: 2]
-
-          unquote(value) >>> fn unquote(assign) -> unquote(continue) end
-        end
+        quote do: unquote(value) |> unquote(chainer).(fn unquote(assign) -> unquote(continue) end)
 
       continue, value ->
-        quote do
-          import Witchcraft.Chain, only: [>>>: 2]
-          unquote(value) >>> fn _ -> unquote(continue) end
-        end
+        quote do: unquote(value) |> unquote(chainer).(fn _ -> unquote(continue) end)
     end)
   end
 


### PR DESCRIPTION
## Summary

This PR fixes `Witchcraft.Chain.do_notation/2`.
Previously it ignored second argument assuming any `chainer` is `Witchcraft.Chain.chain/2`.

However, there is a call of `do_notation/2` across Witchcraft codebase in which `chainer` other then `chain/2` is passed:

https://github.com/witchcrafters/witchcraft/blob/6c61c3ecd5b431c52e8b60aafb05596d9182205e/lib/witchcraft/monad.ex#L284-L287

## Test plan (required)

`mix test` should be enough

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #108 

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [x] Does this change require a release to be made? Is so please create and deploy the release
